### PR TITLE
feat: reconstruct input value from the message limbs

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -583,7 +583,7 @@ mod tests {
     #[test]
     fn test_f1_e2e_with_valid_input() {
         let test_case = create_test_case(16, 4, 123);
-        let script = test_f1_e2e(&test_case);
+        let script = build_f1_e2e_script(&test_case);
         let f1_res = execute_script_buf(script);
         println!("F1 => success={}", f1_res.success);
         println!("F1 => exec_stats={:?}", f1_res.stats);
@@ -596,7 +596,7 @@ mod tests {
     #[test]
     fn test_f1_e2e_with_invalid_input() {
         let test_case = create_test_case(16, 4, 100);
-        let script = test_f1_e2e(&test_case);
+        let script = build_f1_e2e_script(&test_case);
         let f1_res = execute_script_buf(script);
         println!("F1 => success={}", f1_res.success);
         println!("F1 => exec_stats={:?}", f1_res.stats);
@@ -606,7 +606,7 @@ mod tests {
         assert!(!f1_res.success);
     }
 
-    fn test_f1_e2e(test_case: &ColliderVmTestCase) -> ScriptBuf {
+    fn build_f1_e2e_script(test_case: &ColliderVmTestCase) -> ScriptBuf {
         // ******************************************************
         // CONSTRUCT A DEBUGGING SCRIPT
         // ******************************************************

--- a/src/core.rs
+++ b/src/core.rs
@@ -677,7 +677,6 @@ mod tests {
     /// duplicates (keeps) the first 8 nibbles, accumulates them into `x`,
     /// leaves `x` on the *altstack*, original 24 nibbles untouched.
     fn script_reconstruct_x_from_first_8_nibbles() -> ScriptBuf {
-        const TOTAL_NIBBLES: i64 = 24; // 12 bytes ×2
         let mut b = Builder::new()
             .push_int(0) // acc = 0
             .push_opcode(opcodes::all::OP_TOALTSTACK);

--- a/src/core.rs
+++ b/src/core.rs
@@ -698,7 +698,7 @@ mod tests {
         full_f1.extend(test_case.sig_script_f1.to_bytes());
         full_f1.extend(debug_script.to_bytes());
         let exec_f1_script = ScriptBuf::from_bytes(full_f1);
-        return exec_f1_script;
+        exec_f1_script
     }
 
     #[test]

--- a/src/core.rs
+++ b/src/core.rs
@@ -581,9 +581,32 @@ mod tests {
     }
 
     #[test]
-    fn test_f1_e2e() {
+    fn test_f1_e2e_with_valid_input() {
         let test_case = create_test_case(16, 4, 123);
+        let script = test_f1_e2e(&test_case);
+        let f1_res = execute_script_buf(script);
+        println!("F1 => success={}", f1_res.success);
+        println!("F1 => exec_stats={:?}", f1_res.stats);
+        println!("F1 => final_stack={:?}", f1_res.final_stack);
+        println!("F1 => error={:?}", f1_res.error);
+        println!("F1 => last_opcode={:?}", f1_res.last_opcode);
+        assert!(f1_res.success);
+    }
 
+    #[test]
+    fn test_f1_e2e_with_invalid_input() {
+        let test_case = create_test_case(16, 4, 100);
+        let script = test_f1_e2e(&test_case);
+        let f1_res = execute_script_buf(script);
+        println!("F1 => success={}", f1_res.success);
+        println!("F1 => exec_stats={:?}", f1_res.stats);
+        println!("F1 => final_stack={:?}", f1_res.final_stack);
+        println!("F1 => error={:?}", f1_res.error);
+        println!("F1 => last_opcode={:?}", f1_res.last_opcode);
+        assert!(!f1_res.success);
+    }
+
+    fn test_f1_e2e(test_case: &ColliderVmTestCase) -> ScriptBuf {
         // ******************************************************
         // CONSTRUCT A DEBUGGING SCRIPT
         // ******************************************************
@@ -648,14 +671,7 @@ mod tests {
         full_f1.extend(test_case.sig_script_f1.to_bytes());
         full_f1.extend(debug_script.to_bytes());
         let exec_f1_script = ScriptBuf::from_bytes(full_f1);
-
-        let f1_res = execute_script_buf(exec_f1_script);
-        println!("F1 => success={}", f1_res.success);
-        println!("F1 => exec_stats={:?}", f1_res.stats);
-        println!("F1 => final_stack={:?}", f1_res.final_stack);
-        println!("F1 => error={:?}", f1_res.error);
-        println!("F1 => last_opcode={:?}", f1_res.last_opcode);
-        assert!(f1_res.success);
+        return exec_f1_script;
     }
 
     /// duplicates (keeps) the first 8 nibbles, accumulates them into `x`,

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -358,15 +358,14 @@ pub fn online_execution(
         flow_id
     );
     thread::sleep(Duration::from_millis(300));
-    let x_sig_script_f1 = {
+    let sig_script_f1 = {
         let mut b = Builder::new();
-        b = b.push_int(input_value as i64);
         b = b.push_slice(sig_f1_buf);
         b.into_script()
     };
 
     let mut full_f1 = msg_push_script_f1.to_bytes();
-    full_f1.extend(x_sig_script_f1.to_bytes());
+    full_f1.extend(sig_script_f1.to_bytes());
     full_f1.extend(step_f1.locking_script.to_bytes());
     let exec_f1_script = ScriptBuf::from_bytes(full_f1);
 


### PR DESCRIPTION
- updated function `build_script_f1_blake3_locked` that reconstructs the input value from the message limbs
- removed the input value from `x_sig_script_f1` in the function `online_execution`
- updated function `script_reconstruct_x_from_first_8_nibbles` that reconstructs the input value correctly
- added tests for valid input (x > 100) and invalid input (x < 100)